### PR TITLE
Add CODEOWNERS and .syncignore.

### DIFF
--- a/.github/.syncignore
+++ b/.github/.syncignore
@@ -1,0 +1,1 @@
+CODEOWNERS

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @paketo-buildpacks/stacks-maintainers


### PR DESCRIPTION
## Summary

Add CODEOWNERS and .syncignore. Other stacks have them - not sure why this got missed back when the branch was pushed in August 2022.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
