### PR TITLE
Add libssl-dev to build image for parity

### DIFF
--- a/stack/stack.toml
+++ b/stack/stack.toml
@@ -27,6 +27,7 @@ platforms = ["linux/amd64"]
     libexpat1 \
     libgmp-dev \
     libssl3 \
+    libssl-dev \
     libyaml-0-2 \
     netbase \
     openssl \


### PR DESCRIPTION
## Summary

Right now, the base build image includes `libssl3` but does not include the corresponding dev files. Since this is the build image, it stands to reason users might want the `libssl` build files. This PR adds the package for the libssl dev files.

## Use Cases

Build any application that uses libssl and builds native code against it (i.e. it requires headers).

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
