### PR TITLE
Add pkg-config to build image

### DIFF
--- a/stack/stack.toml
+++ b/stack/stack.toml
@@ -31,6 +31,7 @@ platforms = ["linux/amd64"]
     libyaml-0-2 \
     netbase \
     openssl \
+    pkg-config \
     tzdata \
     xz-utils \
     zlib1g-dev \


### PR DESCRIPTION
## Summary

Right now, the base build image does not include `pkg-config` which is a very common tool used by build systems to check for the existence of C libraries on the system & find out critical information like where libraries and headers live. I propose we should add this to the builder image so that tools can use it to locate needed libraries.

## Use Cases

Many build systems run this tool to locate required libraries. We have had an issue with Rust projects failing, because crates that depend on C libraries use this tool to locate them at build time.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
