### PR TITLE
test with released images instead of building ourselves

### DIFF
--- a/buildpack_integration_test.go
+++ b/buildpack_integration_test.go
@@ -47,27 +47,10 @@ func testBuildpackIntegration(t *testing.T, context spec.G, it spec.S) {
 		name, err = occam.RandomName()
 		Expect(err).NotTo(HaveOccurred())
 
-		buildpackStore := occam.NewBuildpackStore()
-
-		mavenBuildpack, err = buildpackStore.Get.
-			WithVersion("6.5.5").
-			Execute("github.com/paketo-buildpacks/maven")
-		Expect(err).NotTo(HaveOccurred())
-
-		jvmBuildpack, err = buildpackStore.Get.
-			WithVersion("9.3.4").
-			Execute("github.com/paketo-buildpacks/sap-machine")
-		Expect(err).NotTo(HaveOccurred())
-
-		syftBuildpack, err = buildpackStore.Get.
-			WithVersion("1.12.0").
-			Execute("github.com/paketo-buildpacks/syft")
-		Expect(err).NotTo(HaveOccurred())
-
-		executableJarBuildpack, err = buildpackStore.Get.
-			WithVersion("6.2.4").
-			Execute("github.com/paketo-buildpacks/executable-jar")
-		Expect(err).NotTo(HaveOccurred())
+		mavenBuildpack = "gcr.io/paketo-buildpacks/maven"
+		jvmBuildpack = "gcr.io/paketo-buildpacks/sap-machine"
+		syftBuildpack = "gcr.io/paketo-buildpacks/syft"
+		executableJarBuildpack = "gcr.io/paketo-buildpacks/executable-jar"
 
 		source, err = occam.Source(filepath.Join("integration", "testdata", "simple_app"))
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
Multi-arch images are now available in Paketo, and as a result the integration tests are failing due to the new format of the packaged buildpacks (ex. `<buildpack>/bin/build` -> `<buildpack>/linux/amd64/bin/build`)

The issue can be resolved in 1 of 2 ways:
1. Use the released buildpack images in the tests, rather than building them ourselves with occam buildpackstore
2. Use the [experimental pack CLI](https://github.com/buildpacks/pack/actions/runs/8191662078) which has multi-arch support. It's not released yet, but once it is released, these failures will cease.

I've chosen option 1 here