### PR TITLE
Limit the number of receipts in the release notes

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -457,6 +457,7 @@ jobs:
         run_packages_removed_with_force: "/github/workspace/${{ env.RUN_DIFF_REMOVED_FILENAME }}"
         patched_usns: ${{ needs.poll_usns.outputs.usns }}
         release_body_file: "/github/workspace/release-body.md"
+        receipts_show_limit: 100
 
     - name: Setup Release Assets
       id: assets


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
Limiting the number of receipts should help address the issue of reaching body size limit (as seen [here](https://github.com/paketo-buildpacks/jammy-base-stack/actions/runs/14015282057/job/39240262734)) and unblock the release process.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
