### PR TITLE
Adding python 3 on the build image

### DIFF
--- a/stack/stack.toml
+++ b/stack/stack.toml
@@ -30,10 +30,13 @@ platforms = ["linux/amd64", "linux/arm64"]
     libgmp-dev \
     libssl3 \
     libssl-dev \
+    libpython3-stdlib \
+    libpython3.10 \
     libyaml-0-2 \
     netbase \
     openssl \
     pkg-config \
+    python3 \
     tzdata \
     xz-utils \
     zlib1g-dev \


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR adds python 3 on the build image

( Comment: copy pasted from builders slack channel) 

We test all nodejs buildpacks against buildpackless-base builders. The only exception is on npm-install where we use the buildpackless-full builder due to in some tests we need to compile some native modules where python is necessary (see [integration.json](https://github.com/paketo-buildpacks/npm-install/blob/1f3a1be68552fca35bf613090cd55c4f3d9dff2b/integration.json#L5C23-L5C55) file) Long story short, we need python on the build image (not on the run image) for one of the buildpacks.
In addition, except the fact that the integration tests do not pass (for the native modules) if we use other builder except the buildpackless-full, in the real world, if the user try to build npm modules that have native modules in it, it will fail in case it uses the buildpackless-base which I guess is the most common builder being used based dockerhub downloads (base ~= 500k , full ~= 100k)
Similarly for the noble images.
I added python on the base build image and on the builder and the increase in size is approximately 37 mbs.

Jammy:
```
# build jammy image
localhost:5000/build-jammy-base                     0.0.1                1289021beab9   2 hours ago    435MB
paketobuildpacks/build-jammy-base                   latest               062128aca33b   12 days ago    398MB
```

Noble:
```
localhost:5000/ubuntu-noble-build                   0.0.1                5a610b7ed976   13 minutes ago   483MB
paketobuildpacks/ubuntu-noble-build                 latest               0b3ec3d57f2c   12 days ago      436MB
```

The pros from this increase:
* Will let free the nodejs buildpacks from the full builder, and this will also let the nodejs buildpacks to transition to the noble builder, as there is no other use case where we need full builder.
* Faster integration tests and also less failures on the CI as the full builder constantly fails to get saved on the disk due to its size
* No more errors for the end user ( where the app includes native modules) in case they try to build an app with the base builder (which is the most common senario)
* Adds the ability to build apps with npm native modules in noble builders, as currently it is not possible to build an app with npm native modules, as non of the builders includes python.
* It does not increase the image size of the run image hence it does not also increase the image size of the build app image.
* One step closer for deprecating full builder from the paketo org

Cons:
* 37mbs increase on the build image, for jammy
* 47mbs increase on the build image (with the fontconfig in it), for noble

Potential Pros:
* might other buildpacks too get benefit from that

Final thoughts:
* On ubi8 and ubi9 python is available during the build process so why not on the ubuntu too?


## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
